### PR TITLE
Improve game rules api consistency

### DIFF
--- a/src/EightBall.elm
+++ b/src/EightBall.elm
@@ -1,8 +1,8 @@
 module EightBall exposing
-    ( Pool, AwaitingRack, AwaitingNextShot, AwaitingBallInHand, AwaitingPlaceBallBehindHeadstring, AwaitingNewGame, start
+    ( Pool, AwaitingRack, AwaitingPlayerShot, AwaitingPlaceBallInHand, AwaitingPlaceBallBehindHeadstring, AwaitingStart, start
     , currentPlayer, currentScore
     , CurrentTarget(..), currentTarget
-    , rack, ballPlacedBehindHeadString, ballPlacedInHand, playerShot
+    , rack, placeBallBehindHeadstring, placeBallInHand, playerShot
     , ShotEvent
     , cueHitBall, cueHitWall, ballFellInPocket, ballHitWall, scratch
     , Ball, oneBall, twoBall, threeBall, fourBall, fiveBall, sixBall, sevenBall, eightBall, nineBall, tenBall, elevenBall, twelveBall, thirteenBall, fourteenBall, fifteenBall, numberedBall, ballNumber
@@ -23,7 +23,7 @@ module EightBall exposing
 
 # Init
 
-@docs Pool, AwaitingRack, AwaitingNextShot, AwaitingBallInHand, AwaitingPlaceBallBehindHeadstring, AwaitingNewGame, start
+@docs Pool, AwaitingRack, AwaitingPlayerShot, AwaitingPlaceBallInHand, AwaitingPlaceBallBehindHeadstring, AwaitingStart, start
 
 
 # View
@@ -35,7 +35,7 @@ module EightBall exposing
 
 # Update
 
-@docs rack, ballPlacedBehindHeadString, ballPlacedInHand, playerShot
+@docs rack, placeBallBehindHeadstring, placeBallInHand, playerShot
 
 
 ## Shot Events
@@ -379,8 +379,8 @@ type AwaitingRack
 
 {-| Ready for a player to take another shot.
 -}
-type AwaitingNextShot
-    = AwaitingNextShot
+type AwaitingPlayerShot
+    = AwaitingPlayerShot
 
 
 {-| When a player scratches, or otherwise fouls, during regular play, the next player is given ball-in-hand anywhere on the table.
@@ -388,8 +388,8 @@ type AwaitingNextShot
 See [WPA rules](https://wpapool.com/rules-of-play/) 1.5 Cue Ball in Hand for more info.
 
 -}
-type AwaitingBallInHand
-    = AwaitingBallInHand
+type AwaitingPlaceBallInHand
+    = AwaitingPlaceBallInHand
 
 
 {-| This is the area where the player can place the cue ball before a break.
@@ -408,8 +408,8 @@ type AwaitingPlaceBallBehindHeadstring
 
 {-| When the game is over, start a new game to play again.
 -}
-type AwaitingNewGame
-    = AwaitingNewGame
+type AwaitingStart
+    = AwaitingStart
 
 
 {-| The balls must be racked before the player can place the cue ball and break.
@@ -459,8 +459,8 @@ type ShotEvent
 
 {-| When the ball is placed behind the head string after racking.
 -}
-ballPlacedBehindHeadString : Time.Posix -> Pool AwaitingPlaceBallBehindHeadstring -> Pool AwaitingNextShot
-ballPlacedBehindHeadString when (Pool data) =
+placeBallBehindHeadstring : Time.Posix -> Pool AwaitingPlaceBallBehindHeadstring -> Pool AwaitingPlayerShot
+placeBallBehindHeadstring when (Pool data) =
     Pool
         { data
             | events =
@@ -474,8 +474,8 @@ ballPlacedBehindHeadString when (Pool data) =
 
 {-| When the ball is placed anywhere on the table.
 -}
-ballPlacedInHand : Time.Posix -> Pool AwaitingBallInHand -> Pool AwaitingNextShot
-ballPlacedInHand when (Pool data) =
+placeBallInHand : Time.Posix -> Pool AwaitingPlaceBallInHand -> Pool AwaitingPlayerShot
+placeBallInHand when (Pool data) =
     Pool
         { data
             | events =
@@ -574,10 +574,10 @@ scratch when =
 
 -}
 type WhatHappened
-    = PlayersFault (Pool AwaitingBallInHand)
-    | NextShot (Pool AwaitingNextShot)
+    = PlayersFault (Pool AwaitingPlaceBallInHand)
+    | NextShot (Pool AwaitingPlayerShot)
       -- | NextTurn (Pool AwaitingNextTurn)
-    | GameOver (Pool AwaitingNewGame) { winner : Int }
+    | GameOver (Pool AwaitingStart) { winner : Int }
     | Error String
 
 
@@ -607,7 +607,7 @@ Note: if no balls are hit by the cue ball, send an empty list.
     playerShot [] pool -- Cue struck, but no other balls hit.
 
 -}
-playerShot : List ( Time.Posix, ShotEvent ) -> Pool AwaitingNextShot -> WhatHappened
+playerShot : List ( Time.Posix, ShotEvent ) -> Pool AwaitingPlayerShot -> WhatHappened
 playerShot shotEvents (Pool data) =
     case shotEvents of
         [] ->

--- a/src/EightBall.elm
+++ b/src/EightBall.elm
@@ -1,5 +1,5 @@
 module EightBall exposing
-    ( Pool, AwaitingRack, AwaitingPlayerShot, AwaitingPlaceBallInHand, AwaitingPlaceBallBehindHeadstring, AwaitingStart, start
+    ( Pool, start, AwaitingRack, AwaitingPlayerShot, AwaitingPlaceBallInHand, AwaitingPlaceBallBehindHeadstring, AwaitingStart
     , currentPlayer, currentScore
     , CurrentTarget(..), currentTarget
     , rack, placeBallBehindHeadstring, placeBallInHand, playerShot
@@ -23,7 +23,7 @@ module EightBall exposing
 
 # Init
 
-@docs Pool, AwaitingRack, AwaitingPlayerShot, AwaitingPlaceBallInHand, AwaitingPlaceBallBehindHeadstring, AwaitingStart, start
+@docs Pool, start, AwaitingRack, AwaitingPlayerShot, AwaitingPlaceBallInHand, AwaitingPlaceBallBehindHeadstring, AwaitingStart
 
 
 # View
@@ -267,6 +267,13 @@ numberedBall number =
         Nothing
 
 
+{-| Get the int value for a ball:
+
+    ballNumber eightBall == 8
+
+    ballNumber fifteenBall == 15
+
+-}
 ballNumber : Ball -> Int
 ballNumber (Ball n _) =
     n
@@ -372,12 +379,15 @@ currentTarget (Pool ({ pocketed } as poolData)) =
 
 
 {-| Waiting for the balls to be racked.
+
+Use `rack` when in this state.
+
 -}
 type AwaitingRack
     = AwaitingRack
 
 
-{-| Ready for a player to take another shot.
+{-| Ready for a player to take a shot.
 -}
 type AwaitingPlayerShot
     = AwaitingPlayerShot

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -11,7 +11,7 @@ import Cylinder3d
 import Dict exposing (Dict)
 import Direction3d
 import Duration exposing (Duration, seconds)
-import EightBall exposing (AwaitingBallInHand, AwaitingNewGame, AwaitingNextShot, AwaitingPlaceBallBehindHeadstring, Pool, ShotEvent, WhatHappened(..))
+import EightBall exposing (AwaitingPlaceBallBehindHeadstring, AwaitingPlaceBallInHand, AwaitingPlayerShot, AwaitingStart, Pool, ShotEvent, WhatHappened(..))
 import Force
 import Frame3d
 import Html exposing (Html)
@@ -72,12 +72,12 @@ type State
     = PlacingBehindHeadString (PlacingBallState AwaitingPlaceBallBehindHeadstring)
     | Playing PlayingState
     | Simulating SimulatingState
-    | PlacingBallInHand (PlacingBallState AwaitingBallInHand)
-    | GameOver (EightBall.Pool AwaitingNewGame) Int
+    | PlacingBallInHand (PlacingBallState AwaitingPlaceBallInHand)
+    | GameOver (EightBall.Pool AwaitingStart) Int
 
 
 type alias PlayingState =
-    { pool : Pool AwaitingNextShot
+    { pool : Pool AwaitingPlayerShot
     , cueBallPosition : Point3d Meters WorldCoordinates
     , cueElevation : Angle
     , hitElevation : Angle
@@ -93,7 +93,7 @@ type PlayingMouse
     | NothingMeaningful
 
 
-initialPlayingState : Point3d Meters WorldCoordinates -> Pool AwaitingNextShot -> State
+initialPlayingState : Point3d Meters WorldCoordinates -> Pool AwaitingPlayerShot -> State
 initialPlayingState cueBallPosition pool =
     Playing
         { pool = pool
@@ -128,11 +128,11 @@ initialPlacingBallState fn pool =
 
 type alias SimulatingState =
     { events : List ( Time.Posix, ShotEvent )
-    , pool : Pool AwaitingNextShot
+    , pool : Pool AwaitingPlayerShot
     }
 
 
-initialSimulatingState : Pool AwaitingNextShot -> State
+initialSimulatingState : Pool AwaitingPlayerShot -> State
 initialSimulatingState pool =
     Simulating
         { pool = pool
@@ -863,7 +863,7 @@ update msg model =
                     case canSpawnHere (ray model mouse) Bodies.areaBallInHand model.world of
                         CanSpawnAt position ->
                             { model
-                                | state = initialPlayingState position (EightBall.ballPlacedInHand model.time pool)
+                                | state = initialPlayingState position (EightBall.placeBallInHand model.time pool)
                                 , world = World.add (Body.moveTo position Bodies.cueBall) model.world
                                 , focalPointTimeline =
                                     Animator.go Animator.quickly
@@ -881,7 +881,7 @@ update msg model =
                     case canSpawnHere (ray model mouse) Bodies.areaBehindTheHeadString model.world of
                         CanSpawnAt position ->
                             { model
-                                | state = initialPlayingState position (EightBall.ballPlacedBehindHeadString model.time pool)
+                                | state = initialPlayingState position (EightBall.placeBallBehindHeadstring model.time pool)
                                 , world = World.add (Body.moveTo position Bodies.cueBall) model.world
                                 , focalPointTimeline =
                                     Animator.go Animator.quickly

--- a/tests/EightBallTests.elm
+++ b/tests/EightBallTests.elm
@@ -18,7 +18,7 @@ suite =
                             nextAction =
                                 EightBall.start
                                     |> EightBall.rack (Time.millisToPosix 0)
-                                    |> EightBall.ballPlacedBehindHeadString (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
                                     |> EightBall.playerShot []
                         in
                         case nextAction of
@@ -41,7 +41,7 @@ suite =
                             nextAction =
                                 EightBall.start
                                     |> EightBall.rack (Time.millisToPosix 0)
-                                    |> EightBall.ballPlacedBehindHeadString (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
                                     |> EightBall.playerShot
                                         [ EightBall.cueHitBall (Time.millisToPosix 1) EightBall.oneBall
                                         , EightBall.ballFellInPocket (Time.millisToPosix 1) EightBall.oneBall
@@ -67,7 +67,7 @@ suite =
                             nextAction =
                                 EightBall.start
                                     |> EightBall.rack (Time.millisToPosix 0)
-                                    |> EightBall.ballPlacedBehindHeadString (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
                                     |> EightBall.playerShot
                                         [ EightBall.cueHitBall (Time.millisToPosix 1) EightBall.oneBall
                                         , EightBall.ballFellInPocket (Time.millisToPosix 1) EightBall.oneBall
@@ -112,7 +112,7 @@ suite =
                             nextAction =
                                 EightBall.start
                                     |> EightBall.rack (Time.millisToPosix 0)
-                                    |> EightBall.ballPlacedBehindHeadString (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
                                     |> EightBall.playerShot []
                         in
                         case nextAction of
@@ -132,7 +132,7 @@ suite =
                             nextAction =
                                 EightBall.start
                                     |> EightBall.rack (Time.millisToPosix 0)
-                                    |> EightBall.ballPlacedBehindHeadString (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
                                     |> EightBall.playerShot
                                         [ EightBall.cueHitBall (Time.millisToPosix 0) EightBall.twoBall
                                         , EightBall.ballHitWall (Time.millisToPosix 1) EightBall.twoBall
@@ -155,7 +155,7 @@ suite =
                             nextAction =
                                 EightBall.start
                                     |> EightBall.rack (Time.millisToPosix 0)
-                                    |> EightBall.ballPlacedBehindHeadString (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
                                     |> EightBall.playerShot []
                                     |> andKeepShooting []
                         in
@@ -176,7 +176,7 @@ suite =
                             nextAction =
                                 EightBall.start
                                     |> EightBall.rack (Time.millisToPosix 0)
-                                    |> EightBall.ballPlacedBehindHeadString (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
                                     |> EightBall.playerShot
                                         [ EightBall.cueHitBall (Time.millisToPosix 1) EightBall.oneBall
                                         , EightBall.ballFellInPocket (Time.millisToPosix 1) EightBall.oneBall
@@ -201,7 +201,7 @@ suite =
                             nextAction =
                                 EightBall.start
                                     |> EightBall.rack (Time.millisToPosix 0)
-                                    |> EightBall.ballPlacedBehindHeadString (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
                                     |> EightBall.playerShot
                                         [ EightBall.cueHitBall (Time.millisToPosix 1) EightBall.fifteenBall
                                         , EightBall.ballFellInPocket (Time.millisToPosix 1) EightBall.tenBall
@@ -225,7 +225,7 @@ suite =
                             nextAction =
                                 EightBall.start
                                     |> EightBall.rack (Time.millisToPosix 0)
-                                    |> EightBall.ballPlacedBehindHeadString (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
                                     |> EightBall.playerShot
                                         [ EightBall.cueHitBall (Time.millisToPosix 1) EightBall.oneBall
                                         , EightBall.ballFellInPocket (Time.millisToPosix 1) EightBall.oneBall
@@ -250,7 +250,7 @@ suite =
                             nextAction =
                                 EightBall.start
                                     |> EightBall.rack (Time.millisToPosix 0)
-                                    |> EightBall.ballPlacedBehindHeadString (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
                                     |> EightBall.playerShot
                                         [ EightBall.cueHitBall (Time.millisToPosix 1) EightBall.oneBall
                                         , EightBall.ballFellInPocket (Time.millisToPosix 1) EightBall.oneBall
@@ -276,7 +276,7 @@ suite =
                             nextAction =
                                 EightBall.start
                                     |> EightBall.rack (Time.millisToPosix 0)
-                                    |> EightBall.ballPlacedBehindHeadString (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
                                     |> EightBall.playerShot
                                         [ EightBall.cueHitBall (Time.millisToPosix 1) EightBall.oneBall
                                         , EightBall.ballFellInPocket (Time.millisToPosix 1) EightBall.oneBall
@@ -310,7 +310,7 @@ suite =
                             nextAction =
                                 EightBall.start
                                     |> EightBall.rack (Time.millisToPosix 0)
-                                    |> EightBall.ballPlacedBehindHeadString (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
                                     |> EightBall.playerShot
                                         [ EightBall.cueHitBall (Time.millisToPosix 1) EightBall.oneBall
                                         , EightBall.ballFellInPocket (Time.millisToPosix 1) EightBall.oneBall
@@ -350,7 +350,7 @@ suite =
                             nextAction =
                                 EightBall.start
                                     |> EightBall.rack (Time.millisToPosix 0)
-                                    |> EightBall.ballPlacedBehindHeadString (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
                                     |> EightBall.playerShot
                                         [ EightBall.cueHitBall (Time.millisToPosix 1) EightBall.nineBall
                                         , EightBall.ballFellInPocket (Time.millisToPosix 1) EightBall.nineBall
@@ -396,7 +396,7 @@ suite =
                             nextAction =
                                 EightBall.start
                                     |> EightBall.rack (Time.millisToPosix 0)
-                                    |> EightBall.ballPlacedBehindHeadString (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
                                     |> EightBall.playerShot
                                         [ EightBall.cueHitBall (Time.millisToPosix 1) EightBall.oneBall
                                         , EightBall.ballFellInPocket (Time.millisToPosix 1) EightBall.oneBall
@@ -430,7 +430,7 @@ suite =
                             nextAction =
                                 EightBall.start
                                     |> EightBall.rack (Time.millisToPosix 0)
-                                    |> EightBall.ballPlacedBehindHeadString (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
                                     |> EightBall.playerShot
                                         [ EightBall.cueHitBall (Time.millisToPosix 1) EightBall.oneBall
                                         ]
@@ -483,7 +483,7 @@ suite =
                             nextAction =
                                 EightBall.start
                                     |> EightBall.rack (Time.millisToPosix 0)
-                                    |> EightBall.ballPlacedBehindHeadString (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
                                     |> EightBall.playerShot
                                         [ EightBall.cueHitBall (Time.millisToPosix 1) EightBall.oneBall
                                         ]
@@ -537,7 +537,7 @@ suite =
                             nextAction =
                                 EightBall.start
                                     |> EightBall.rack (Time.millisToPosix 0)
-                                    |> EightBall.ballPlacedBehindHeadString (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
                                     |> EightBall.playerShot
                                         [ EightBall.cueHitBall (Time.millisToPosix 1) EightBall.oneBall
                                         ]
@@ -590,7 +590,7 @@ suite =
                             nextAction =
                                 EightBall.start
                                     |> EightBall.rack (Time.millisToPosix 0)
-                                    |> EightBall.ballPlacedBehindHeadString (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
                                     |> EightBall.playerShot
                                         [ EightBall.cueHitBall (Time.millisToPosix 1) EightBall.oneBall
                                         ]
@@ -626,7 +626,7 @@ suite =
                             nextAction =
                                 EightBall.start
                                     |> EightBall.rack (Time.millisToPosix 0)
-                                    |> EightBall.ballPlacedBehindHeadString (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
                                     |> EightBall.playerShot
                                         [ EightBall.cueHitBall (Time.millisToPosix 1) EightBall.oneBall
                                         , EightBall.ballFellInPocket (Time.millisToPosix 2) EightBall.oneBall
@@ -656,7 +656,7 @@ suite =
                             nextAction =
                                 EightBall.start
                                     |> EightBall.rack (Time.millisToPosix 0)
-                                    |> EightBall.ballPlacedBehindHeadString (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
                                     |> EightBall.playerShot
                                         [ EightBall.cueHitBall (Time.millisToPosix 1) EightBall.nineBall
                                         , EightBall.ballFellInPocket (Time.millisToPosix 2) EightBall.nineBall
@@ -686,7 +686,7 @@ suite =
                             nextAction =
                                 EightBall.start
                                     |> EightBall.rack (Time.millisToPosix 0)
-                                    |> EightBall.ballPlacedBehindHeadString (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
                                     |> EightBall.playerShot
                                         [ EightBall.cueHitBall (Time.millisToPosix 1) EightBall.oneBall
                                         ]
@@ -742,7 +742,7 @@ suite =
                             nextAction =
                                 EightBall.start
                                     |> EightBall.rack (Time.millisToPosix 0)
-                                    |> EightBall.ballPlacedBehindHeadString (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
                                     |> EightBall.playerShot []
                         in
                         case nextAction of
@@ -764,7 +764,7 @@ suite =
                             nextAction =
                                 EightBall.start
                                     |> EightBall.rack (Time.millisToPosix 0)
-                                    |> EightBall.ballPlacedBehindHeadString (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
                                     |> EightBall.playerShot
                                         [ EightBall.cueHitBall (Time.millisToPosix 1) EightBall.oneBall
 
@@ -790,7 +790,7 @@ suite =
                             nextAction =
                                 EightBall.start
                                     |> EightBall.rack (Time.millisToPosix 0)
-                                    |> EightBall.ballPlacedBehindHeadString (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
                                     |> EightBall.playerShot
                                         [ EightBall.cueHitWall (Time.millisToPosix 1)
                                         , EightBall.cueHitBall (Time.millisToPosix 1) EightBall.oneBall
@@ -815,7 +815,7 @@ suite =
                             nextAction =
                                 EightBall.start
                                     |> EightBall.rack (Time.millisToPosix 0)
-                                    |> EightBall.ballPlacedBehindHeadString (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
                                     |> EightBall.playerShot
                                         [ EightBall.cueHitBall (Time.millisToPosix 1) EightBall.oneBall
                                         , EightBall.ballHitWall (Time.millisToPosix 1) EightBall.oneBall
@@ -840,7 +840,7 @@ suite =
                             nextAction =
                                 EightBall.start
                                     |> EightBall.rack (Time.millisToPosix 0)
-                                    |> EightBall.ballPlacedBehindHeadString (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
                                     |> EightBall.playerShot
                                         [ EightBall.cueHitBall (Time.millisToPosix 1) EightBall.oneBall
                                         , EightBall.cueHitWall (Time.millisToPosix 1)
@@ -867,7 +867,7 @@ suite =
                             nextAction =
                                 EightBall.start
                                     |> EightBall.rack (Time.millisToPosix 0)
-                                    |> EightBall.ballPlacedBehindHeadString (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
                                     |> EightBall.playerShot
                                         [ EightBall.cueHitBall (Time.millisToPosix 1) EightBall.oneBall
                                         , EightBall.scratch (Time.millisToPosix 789)
@@ -890,7 +890,7 @@ suite =
                             nextAction =
                                 EightBall.start
                                     |> EightBall.rack (Time.millisToPosix 0)
-                                    |> EightBall.ballPlacedBehindHeadString (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
                                     |> EightBall.playerShot
                                         [ EightBall.cueHitBall (Time.millisToPosix 1) EightBall.oneBall
                                         , EightBall.scratch (Time.millisToPosix 789)
@@ -899,7 +899,7 @@ suite =
                         case nextAction of
                             EightBall.PlayersFault pool ->
                                 pool
-                                    |> EightBall.ballPlacedInHand (Time.millisToPosix 800)
+                                    |> EightBall.placeBallInHand (Time.millisToPosix 800)
                                     |> EightBall.currentPlayer
                                     |> Expect.equal 1
 
@@ -931,7 +931,7 @@ andKeepShooting shotEvents ruling =
 
         EightBall.PlayersFault pool ->
             pool
-                |> EightBall.ballPlacedInHand lastEventTime
+                |> EightBall.placeBallInHand lastEventTime
                 |> EightBall.playerShot shotEvents
 
         EightBall.GameOver _ _ ->


### PR DESCRIPTION
I renamed a few things for consistency. 

Examples:
- `AwaitingNextShot`->`AwaitingPlayerShot` so it matches the `playerShot` function
- `AwaitingBallInHand`->`AwaitingPlaceBallInHand` and `ballPlacedInHand`->`placeBallInHand` so they match