### PR TITLE
Ball off table

### DIFF
--- a/src/EightBall.elm
+++ b/src/EightBall.elm
@@ -1058,6 +1058,21 @@ eightBallOffTableEvent ( _, shotEvent ) =
             False
 
 
+nonEightBallOffTable : List ( Time.Posix, ShotEvent ) -> Bool
+nonEightBallOffTable shotEvents =
+    List.any nonEightBallOffTableEvent shotEvents
+
+
+nonEightBallOffTableEvent : ( Time.Posix, ShotEvent ) -> Bool
+nonEightBallOffTableEvent ( _, shotEvent ) =
+    case shotEvent of
+        BallOffTable ball ->
+            ball /= eightBall
+
+        _ ->
+            False
+
+
 checkShot : List ( Time.Posix, ShotEvent ) -> BallPocketedEvents -> CurrentTarget -> PoolData -> WhatHappened
 checkShot shotEvents ballPocketedEvents previousTarget poolData =
     if ballPocketedEvents.eightBallPocketed then
@@ -1080,7 +1095,11 @@ checkShot shotEvents ballPocketedEvents previousTarget poolData =
                 GameOver (endGame (Pool poolData))
                     { winner = switchPlayer poolData.player }
 
-    else if ballPocketedEvents.scratched || not (isLegalHit shotEvents previousTarget) then
+    else if
+        ballPocketedEvents.scratched
+            || not (isLegalHit shotEvents previousTarget)
+            || nonEightBallOffTable shotEvents
+    then
         PlayersFault <|
             PlaceBallInHand <|
                 Pool

--- a/src/EightBall.elm
+++ b/src/EightBall.elm
@@ -601,8 +601,7 @@ scratch when =
 -}
 type WhatHappened
     = IllegalBreak (Pool AwaitingRack)
-    | PlayersFault NextPlayerAction --SpotEightBall
-      -- | PlayersFaultSpotEight (Pool AwaitingPlaceBallInHand)
+    | PlayersFault NextPlayerAction
     | NextShot (Pool AwaitingPlayerShot)
     | GameOver (Pool AwaitingStart) { winner : Player }
 

--- a/src/EightBall.elm
+++ b/src/EightBall.elm
@@ -608,7 +608,7 @@ type WhatHappened
 
 type NextPlayerAction
     = SpotEightBall (Pool AwaitingSpotEightBall)
-      -- | ChooseNextAction (List NextPlayerAction)
+      -- | ChooseNextAction NextPlayerAction NextPlayerAction (List NextPlayerAction)
     | PlaceBallInHand (Pool AwaitingPlaceBallInHand)
 
 

--- a/src/EightBall.elm
+++ b/src/EightBall.elm
@@ -2,11 +2,11 @@ module EightBall exposing
     ( Pool, start, AwaitingRack, AwaitingPlayerShot, AwaitingPlaceBallInHand, AwaitingPlaceBallBehindHeadstring, AwaitingStart
     , Player(..), currentPlayer, currentScore
     , CurrentTarget(..), currentTarget
-    , rack, placeBallBehindHeadstring, placeBallInHand, playerShot
+    , rack, placeBallBehindHeadstring, placeBallInHand, playerShot, spotEightBall
     , ShotEvent
-    , cueHitBall, cueHitWall, ballFellInPocket, ballHitWall, scratch
+    , cueHitBall, cueHitWall, ballFellInPocket, ballHitWall, ballOffTable, scratch
     , Ball, oneBall, twoBall, threeBall, fourBall, fiveBall, sixBall, sevenBall, eightBall, nineBall, tenBall, elevenBall, twelveBall, thirteenBall, fourteenBall, fifteenBall, numberedBall, ballNumber
-    , WhatHappened(..)
+    , WhatHappened(..), NextPlayerAction(..)
     )
 
 {-| Pool game rules. Agnostic to game engine.
@@ -35,13 +35,13 @@ module EightBall exposing
 
 # Update
 
-@docs rack, placeBallBehindHeadstring, placeBallInHand, playerShot
+@docs rack, placeBallBehindHeadstring, placeBallInHand, playerShot, spotEightBall
 
 
 ## Shot Events
 
 @docs ShotEvent
-@docs cueHitBall, cueHitWall, ballFellInPocket, ballHitWall, scratch
+@docs cueHitBall, cueHitWall, ballFellInPocket, ballHitWall, ballOffTable, scratch
 
 
 ## Balls
@@ -51,7 +51,7 @@ module EightBall exposing
 
 ## Ruling
 
-@docs WhatHappened
+@docs WhatHappened, NextPlayerAction
 
 -}
 
@@ -400,6 +400,19 @@ type AwaitingPlaceBallBehindHeadstring
     = AwaitingPlaceBallBehindHeadstring Never
 
 
+{-| When a player knocks the eight (8) ball off the table on the break, the 8-ball must be spotted before the next player places ball-in-hand.
+
+From WPA [rules 3.7 Spotting Balls](https://wpapool.com/rules-of-play/#eight-ball)
+
+> If the eight ball is pocketed or driven off the table on the break, it will be spotted or the balls
+> will be re-racked. (See 3.3 Break Shot and 1.4 Spotting Balls.) No other object ball is ever
+> spotted.
+
+-}
+type AwaitingSpotEightBall
+    = AwaitingSpotEightBall Never
+
+
 {-| When the game is over, start a new game to play again.
 -}
 type AwaitingStart
@@ -426,6 +439,7 @@ type InternalEvent
       -- Player actions
     | BallPlacedBehindHeadString
     | BallPlacedInHand
+    | EightBallSpotted
       -- | CallShot Ball Pocket
     | Shot (List ( Time.Posix, ShotEvent ))
       -- Game over
@@ -434,17 +448,15 @@ type InternalEvent
 
 {-| All potential shot events available.
 
-There are a few which should be supported, but are not yet:
+There is one which should be supported, but is not yet:
 
-  - BallOffTable
   - BallToBall
-  - BallToWall
 
 -}
 type ShotEvent
-    = --       -- | BallOffTable Ball
+    = BallOffTable Ball
       -- BallToBall Ball Ball (List Ball)
-      BallToPocket Ball --Pocket
+    | BallToPocket Ball --Pocket
     | BallToWall Ball -- Wall
     | CueHitBall Ball
     | CueHitWall
@@ -476,6 +488,21 @@ placeBallInHand when (Pool data) =
                 data.events
                     ++ [ { when = when
                          , event = BallPlacedInHand
+                         }
+                       ]
+        }
+
+
+{-| When the 8-ball is spotted.
+-}
+spotEightBall : Time.Posix -> Pool AwaitingSpotEightBall -> Pool AwaitingPlaceBallBehindHeadstring
+spotEightBall when (Pool data) =
+    Pool
+        { data
+            | events =
+                data.events
+                    ++ [ { when = when
+                         , event = EightBallSpotted
                          }
                        ]
         }
@@ -539,6 +566,15 @@ ballFellInPocket when ball =
     )
 
 
+{-| When a ball is knocked off the table.
+-}
+ballOffTable : Time.Posix -> Ball -> ( Time.Posix, ShotEvent )
+ballOffTable when ball =
+    ( when
+    , BallOffTable ball
+    )
+
+
 {-| When the cue ball is pocketed.
 
 [WPA Rules 8.6](https://wpapool.com/rules-of-play/#86Scratch)
@@ -565,9 +601,16 @@ scratch when =
 -}
 type WhatHappened
     = IllegalBreak (Pool AwaitingRack)
-    | PlayersFault (Pool AwaitingPlaceBallInHand)
+    | PlayersFault NextPlayerAction --SpotEightBall
+      -- | PlayersFaultSpotEight (Pool AwaitingPlaceBallInHand)
     | NextShot (Pool AwaitingPlayerShot)
     | GameOver (Pool AwaitingStart) { winner : Player }
+
+
+type NextPlayerAction
+    = SpotEightBall (Pool AwaitingSpotEightBall)
+      -- | ChooseNextAction (List NextPlayerAction)
+    | PlaceBallInHand (Pool AwaitingPlaceBallInHand)
 
 
 {-| Set game over via this function so we don't forget to add the internal event.
@@ -604,6 +647,11 @@ playerShot shotEvents (Pool data) =
             playerRegularShot shotEvents data
 
         Just BallPlacedInHand ->
+            playerRegularShot shotEvents data
+
+        Just EightBallSpotted ->
+            -- Error "The cue ball must be placed behind the headstring. The API should not allow this."
+            -- Make an assumption for now since we do not handle errors well in the game.
             playerRegularShot shotEvents data
 
         Just (Shot _) ->
@@ -643,6 +691,21 @@ playerBreak shotEvents data =
                             |> List.sortWith eventTimeComparison
                 }
 
+    else if eightBallOffTable shotEvents then
+        PlayersFault <|
+            SpotEightBall <|
+                Pool
+                    { data
+                        | player = switchPlayer data.player
+                        , events =
+                            data.events
+                                ++ [ { event = Shot shotEvents
+                                     , when = lastEventTime data.events
+                                     }
+                                   ]
+                                |> List.sortWith eventTimeComparison
+                    }
+
     else
         -- We can assume the regular shot rules will apply because there are no incongruities.
         playerRegularShot shotEvents data
@@ -653,6 +716,9 @@ numberOfBallsHitWall =
     List.filterMap
         (\( _, shotEvent ) ->
             case shotEvent of
+                BallOffTable _ ->
+                    Nothing
+
                 BallToPocket _ ->
                     Nothing
 
@@ -678,17 +744,18 @@ playerRegularShot shotEvents data =
         [] ->
             -- Assume the cue is struck, but no other balls are hit.
             PlayersFault <|
-                Pool
-                    { data
-                        | player = switchPlayer data.player
-                        , events =
-                            data.events
-                                ++ [ { event = Shot []
-                                     , when = lastEventTime data.events
-                                     }
-                                   ]
-                                |> List.sortWith eventTimeComparison
-                    }
+                PlaceBallInHand <|
+                    Pool
+                        { data
+                            | player = switchPlayer data.player
+                            , events =
+                                data.events
+                                    ++ [ { event = Shot []
+                                         , when = lastEventTime data.events
+                                         }
+                                       ]
+                                    |> List.sortWith eventTimeComparison
+                        }
 
         ( firstShotTime, _ ) :: _ ->
             let
@@ -797,6 +864,9 @@ groupPocketedEvents shotEvents =
             List.filter
                 (\( _, shotEvent ) ->
                     case shotEvent of
+                        BallOffTable _ ->
+                            False
+
                         BallToPocket _ ->
                             True
 
@@ -818,6 +888,9 @@ groupPocketedEvents shotEvents =
             List.any
                 (\( _, shotEvent ) ->
                     case shotEvent of
+                        BallOffTable _ ->
+                            False
+
                         BallToPocket _ ->
                             False
 
@@ -878,6 +951,9 @@ ballGroup (Ball _ group) =
 ballPocketedInGroup : BallGroup -> ( Time.Posix, ShotEvent ) -> Bool
 ballPocketedInGroup ballGroup_ ( _, shotEvent ) =
     case shotEvent of
+        BallOffTable _ ->
+            False
+
         BallToPocket ball ->
             ballGroup ball == ballGroup_
 
@@ -948,6 +1024,9 @@ legalFirstBallHitGroup shotEvents =
 hasHitAWallOrPocket : ( Time.Posix, ShotEvent ) -> Bool
 hasHitAWallOrPocket ( _, shotEvent ) =
     case shotEvent of
+        BallOffTable _ ->
+            False
+
         CueHitBall _ ->
             False
 
@@ -961,6 +1040,21 @@ hasHitAWallOrPocket ( _, shotEvent ) =
             True
 
         Scratch ->
+            False
+
+
+eightBallOffTable : List ( Time.Posix, ShotEvent ) -> Bool
+eightBallOffTable shotEvents =
+    List.any eightBallOffTableEvent shotEvents
+
+
+eightBallOffTableEvent : ( Time.Posix, ShotEvent ) -> Bool
+eightBallOffTableEvent ( _, shotEvent ) =
+    case shotEvent of
+        BallOffTable ball ->
+            ball == eightBall
+
+        _ ->
             False
 
 
@@ -987,15 +1081,15 @@ checkShot shotEvents ballPocketedEvents previousTarget poolData =
                     { winner = switchPlayer poolData.player }
 
     else if ballPocketedEvents.scratched || not (isLegalHit shotEvents previousTarget) then
-        PlayersFault
-            (Pool
-                { poolData
-                    | player = switchPlayer poolData.player
+        PlayersFault <|
+            PlaceBallInHand <|
+                Pool
+                    { poolData
+                        | player = switchPlayer poolData.player
 
-                    -- TODO: Log Scratched/PlayersFault internal event.
-                    -- Should these be two separate events?
-                }
-            )
+                        -- TODO: Log Scratched/PlayersFault internal event.
+                        -- Should these be two separate events?
+                    }
 
     else
         NextShot <|
@@ -1104,6 +1198,9 @@ lastEventTimeByEventType eventData =
             Just eventData.when
 
         BallPlacedInHand ->
+            Just eventData.when
+
+        EightBallSpotted ->
             Just eventData.when
 
         GameOver_ ->

--- a/src/EightBall.elm
+++ b/src/EightBall.elm
@@ -1075,13 +1075,20 @@ nonEightBallOffTableEvent ( _, shotEvent ) =
 
 checkShot : List ( Time.Posix, ShotEvent ) -> BallPocketedEvents -> CurrentTarget -> PoolData -> WhatHappened
 checkShot shotEvents ballPocketedEvents previousTarget poolData =
-    if ballPocketedEvents.eightBallPocketed then
+    if
+        ballPocketedEvents.eightBallPocketed
+            || eightBallOffTable shotEvents
+    then
         case currentTarget (Pool poolData) of
             EightBall ->
                 -- TODO: Combine case into tuple with new type `Scratched | NotScratched`.
                 let
                     winningPlayer =
-                        if ballPocketedEvents.scratched || not (isLegalHit shotEvents previousTarget) then
+                        if
+                            ballPocketedEvents.scratched
+                                || not (isLegalHit shotEvents previousTarget)
+                                || eightBallOffTable shotEvents
+                        then
                             switchPlayer poolData.player
 
                         else

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -302,12 +302,20 @@ update window msg oldModel =
                         , camera = Camera.focusOn Point3d.origin model.camera
                     }
 
-                Stop (EightBall.PlayersFault newPool) ->
+                Stop (EightBall.PlayersFault (EightBall.PlaceBallInHand newPool)) ->
                     { model
                         | world = World.keepIf (\b -> Body.data b /= CueBall) model.world
                         , state = PlacingBall OutsideOfTable (Anywhere newPool)
                         , camera = Camera.focusOn Point3d.origin model.camera
                     }
+
+                Stop (EightBall.PlayersFault (EightBall.SpotEightBall newPool)) ->
+                    -- { model
+                    --     | world = World.keepIf (\b -> Body.data b /= CueBall) model.world
+                    --     , state = PlacingBall OutsideOfTable (Anywhere newPool)
+                    --     , camera = Camera.focusOn Point3d.origin model.camera
+                    -- }
+                    Debug.todo "Handle spot"
 
                 Stop (EightBall.NextShot newPool) ->
                     let

--- a/tests/EightBallTests.elm
+++ b/tests/EightBallTests.elm
@@ -1036,7 +1036,7 @@ suite =
                     )
                 ]
             , describe "ballOffTable"
-                [ test "when player hits a non-8-ball off the table, the next player must place ball in hand before continuing to shoot"
+                [ test "when player hits a non-8-ball off the table on the break, the next player must place ball in hand before continuing to shoot"
                     (\_ ->
                         let
                             nextAction =
@@ -1047,6 +1047,33 @@ suite =
                                         [ EightBall.cueHitBall (Time.millisToPosix 1) EightBall.oneBall
                                         , EightBall.ballOffTable (Time.millisToPosix 2) EightBall.oneBall
                                         , EightBall.ballFellInPocket (Time.millisToPosix 3) EightBall.thirteenBall
+                                        ]
+                        in
+                        case nextAction of
+                            EightBall.PlayersFault (EightBall.PlaceBallInHand pool) ->
+                                pool
+                                    |> EightBall.currentPlayer
+                                    |> Expect.equal EightBall.Player2
+
+                            other ->
+                                Expect.fail <|
+                                    "Should be EightBall.PlayersFault, but found this instead:\n"
+                                        ++ Debug.toString other
+                    )
+                , test "when player hits a non-8-ball off the table after the break, the next player must place ball in hand before continuing to shoot"
+                    (\_ ->
+                        let
+                            nextAction =
+                                EightBall.start
+                                    |> EightBall.rack (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
+                                    |> EightBall.playerShot
+                                        [ EightBall.cueHitBall (Time.millisToPosix 1) EightBall.oneBall
+                                        , EightBall.ballFellInPocket (Time.millisToPosix 3) EightBall.thirteenBall
+                                        ]
+                                    |> andKeepShooting
+                                        [ EightBall.cueHitBall (Time.millisToPosix 1) EightBall.oneBall
+                                        , EightBall.ballOffTable (Time.millisToPosix 2) EightBall.oneBall
                                         ]
                         in
                         case nextAction of

--- a/tests/EightBallTests.elm
+++ b/tests/EightBallTests.elm
@@ -117,7 +117,7 @@ suite =
                                     |> andKeepShooting []
                         in
                         case nextAction of
-                            EightBall.PlayersFault pool ->
+                            EightBall.PlayersFault (EightBall.PlaceBallInHand pool) ->
                                 pool
                                     |> EightBall.currentPlayer
                                     |> Expect.equal EightBall.Player2
@@ -172,7 +172,7 @@ suite =
                                     |> andKeepShooting []
                         in
                         case nextAction of
-                            EightBall.PlayersFault pool ->
+                            EightBall.PlayersFault (EightBall.PlaceBallInHand pool) ->
                                 pool
                                     |> EightBall.currentPlayer
                                     |> Expect.equal EightBall.Player1
@@ -270,7 +270,7 @@ suite =
                                         ]
                         in
                         case nextAction of
-                            EightBall.PlayersFault pool ->
+                            EightBall.PlayersFault (EightBall.PlaceBallInHand pool) ->
                                 pool
                                     |> Expect.all
                                         [ EightBall.currentTarget >> Expect.equal EightBall.OpenTable
@@ -743,7 +743,7 @@ suite =
                                         ]
                         in
                         case nextAction of
-                            EightBall.PlayersFault pool ->
+                            EightBall.PlayersFault (EightBall.PlaceBallInHand pool) ->
                                 pool
                                     |> Expect.all
                                         [ EightBall.currentPlayer >> Expect.equal EightBall.Player2
@@ -773,7 +773,7 @@ suite =
                                         ]
                         in
                         case nextAction of
-                            EightBall.PlayersFault pool ->
+                            EightBall.PlayersFault (EightBall.PlaceBallInHand pool) ->
                                 pool
                                     |> Expect.all
                                         [ EightBall.currentPlayer >> Expect.equal EightBall.Player2
@@ -828,7 +828,7 @@ suite =
                                         ]
                         in
                         case nextAction of
-                            EightBall.PlayersFault pool ->
+                            EightBall.PlayersFault (EightBall.PlaceBallInHand pool) ->
                                 pool
                                     |> Expect.all
                                         [ EightBall.currentPlayer >> Expect.equal EightBall.Player1
@@ -855,7 +855,7 @@ suite =
                                     |> andKeepShooting []
                         in
                         case nextAction of
-                            EightBall.PlayersFault pool ->
+                            EightBall.PlayersFault (EightBall.PlaceBallInHand pool) ->
                                 pool
                                     |> Expect.all
                                         [ EightBall.currentPlayer >> Expect.equal EightBall.Player2
@@ -886,7 +886,7 @@ suite =
                                         ]
                         in
                         case nextAction of
-                            EightBall.PlayersFault pool ->
+                            EightBall.PlayersFault (EightBall.PlaceBallInHand pool) ->
                                 pool
                                     |> Expect.all
                                         [ EightBall.currentPlayer >> Expect.equal EightBall.Player2
@@ -915,7 +915,7 @@ suite =
                                         ]
                         in
                         case nextAction of
-                            EightBall.PlayersFault pool ->
+                            EightBall.PlayersFault (EightBall.PlaceBallInHand pool) ->
                                 pool
                                     |> Expect.all
                                         [ EightBall.currentPlayer >> Expect.equal EightBall.Player2
@@ -1000,7 +1000,7 @@ suite =
                                         ]
                         in
                         case nextAction of
-                            EightBall.PlayersFault pool ->
+                            EightBall.PlayersFault (EightBall.PlaceBallInHand pool) ->
                                 pool
                                     |> EightBall.currentPlayer
                                     |> Expect.equal EightBall.Player2
@@ -1023,7 +1023,7 @@ suite =
                                         ]
                         in
                         case nextAction of
-                            EightBall.PlayersFault pool ->
+                            EightBall.PlayersFault (EightBall.PlaceBallInHand pool) ->
                                 pool
                                     |> EightBall.placeBallInHand (Time.millisToPosix 800)
                                     |> EightBall.currentPlayer
@@ -1032,6 +1032,86 @@ suite =
                             other ->
                                 Expect.fail <|
                                     "Should be EightBall.PlayersFault, but found this instead:\n"
+                                        ++ Debug.toString other
+                    )
+                ]
+            , describe "ballOffTable"
+                [ test "when player hits a non-8-ball off the table, the next player must place ball in hand before continuing to shoot"
+                    (\_ ->
+                        let
+                            nextAction =
+                                EightBall.start
+                                    |> EightBall.rack (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
+                                    |> EightBall.playerShot
+                                        [ EightBall.cueHitBall (Time.millisToPosix 1) EightBall.oneBall
+                                        , EightBall.ballOffTable (Time.millisToPosix 2) EightBall.oneBall
+                                        , EightBall.ballFellInPocket (Time.millisToPosix 3) EightBall.thirteenBall
+                                        ]
+                        in
+                        case nextAction of
+                            EightBall.PlayersFault (EightBall.PlaceBallInHand pool) ->
+                                pool
+                                    |> EightBall.currentPlayer
+                                    |> Expect.equal EightBall.Player2
+
+                            other ->
+                                Expect.fail <|
+                                    "Should be EightBall.PlayersFault, but found this instead:\n"
+                                        ++ Debug.toString other
+                    )
+                , test "when player hits the 8-ball off the table on the break, the 8-ball is spotted and the next player must place ball in hand before continuing to shoot"
+                    (\_ ->
+                        let
+                            nextAction =
+                                EightBall.start
+                                    |> EightBall.rack (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
+                                    |> EightBall.playerShot
+                                        [ EightBall.cueHitBall (Time.millisToPosix 1) EightBall.oneBall
+                                        , EightBall.ballOffTable (Time.millisToPosix 2) EightBall.eightBall
+                                        , EightBall.ballFellInPocket (Time.millisToPosix 3) EightBall.thirteenBall
+                                        ]
+                        in
+                        case nextAction of
+                            EightBall.PlayersFault (EightBall.SpotEightBall pool) ->
+                                pool
+                                    |> EightBall.currentPlayer
+                                    |> Expect.equal EightBall.Player2
+
+                            other ->
+                                Expect.fail <|
+                                    "Should be EightBall.PlayersFault, but found this instead:\n"
+                                        ++ Debug.toString other
+                    )
+                , test "when player hits the 8-ball off the table AFTER the break, the player loses"
+                    (\_ ->
+                        let
+                            nextAction =
+                                EightBall.start
+                                    |> EightBall.rack (Time.millisToPosix 0)
+                                    |> EightBall.placeBallBehindHeadstring (Time.millisToPosix 0)
+                                    |> EightBall.playerShot
+                                        [ EightBall.cueHitBall (Time.millisToPosix 1) EightBall.oneBall
+                                        , EightBall.ballFellInPocket (Time.millisToPosix 1) EightBall.oneBall
+                                        ]
+                                    |> andKeepShooting
+                                        [ EightBall.cueHitBall (Time.millisToPosix 1) EightBall.twoBall
+                                        , EightBall.ballFellInPocket (Time.millisToPosix 2) EightBall.threeBall
+                                        , EightBall.ballFellInPocket (Time.millisToPosix 3) EightBall.fiveBall
+                                        ]
+                                    |> andKeepShooting
+                                        [ EightBall.ballOffTable (Time.millisToPosix 2) EightBall.eightBall
+                                        , EightBall.ballFellInPocket (Time.millisToPosix 3) EightBall.thirteenBall
+                                        ]
+                        in
+                        case nextAction of
+                            EightBall.GameOver _ { winner } ->
+                                Expect.equal winner EightBall.Player2
+
+                            other ->
+                                Expect.fail <|
+                                    "Should be EightBall.GameOver, but found this instead:\n"
                                         ++ Debug.toString other
                     )
                 ]
@@ -1055,9 +1135,15 @@ andKeepShooting shotEvents ruling =
         EightBall.NextShot pool ->
             EightBall.playerShot shotEvents pool
 
-        EightBall.PlayersFault pool ->
+        EightBall.PlayersFault (EightBall.PlaceBallInHand pool) ->
             pool
                 |> EightBall.placeBallInHand lastEventTime
+                |> EightBall.playerShot shotEvents
+
+        EightBall.PlayersFault (EightBall.SpotEightBall pool) ->
+            pool
+                |> EightBall.spotEightBall lastEventTime
+                |> EightBall.placeBallBehindHeadstring lastEventTime
                 |> EightBall.playerShot shotEvents
 
         EightBall.GameOver _ _ ->


### PR DESCRIPTION
Handle when a ball goes off the table. 

Currently, we treat ball-off-table as pocketed.

New scenarios to consider:
1. 8-ball off table on break - 8-ball is spotted. Other player has ball-in-hand behind headstring. (Future: give option to re-rack instead.)
2. 8-ball off table after break - Player loses. 😢 
3.  Non-8-ball off table on break. Ball not spotted. Other player has ball-in-hand behind headstring. (Future: give option to accept the "table in position".)
4. Non-8-ball off table after break. Ball not spotted. Other player has ball-in-hand. (Future: give option to accept the "table in position".)

TODO:
- [x] Check if ball is off the table instead of considering it pocketed.
- [x] Handle spotting the 8-ball once #34 is merged.